### PR TITLE
switch from wildcard version to semver-minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use `glob`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-glob = "*"
+glob = "0.2"
 ```
 
 And add this to your crate root:


### PR DESCRIPTION
Previously the readme used the "old" `*` to include glob; now it uses the "semver-minor version-style". 