### PR TITLE
Add example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ And add this to your crate root:
 extern crate glob;
 ```
 
+## Examples
+
+Print all jpg files in /media/ and all of its subdirectories.
+
+```rust
+use glob::glob;
+
+for entry in glob("/media/**/*.jpg").expect("Failed to read glob pattern") {
+    match entry {
+        Ok(path) => println!("{:?}", path.display()),
+        Err(e) => println!("{:?}", e),
+    }
+}
+```


### PR DESCRIPTION
In https://github.com/rust-lang-nursery/rand README, the last part of the readme is examples. It's usual (and cool IMO) to see usage examples in README on github, that's why I submit this PR. Anyway it's not a great PR, it's just a copy/paste from the doc, but maybe it's better for users to have a quick example directly on the github project page. I can edit if you think I can do better (or close if it's a bad idea)