### PR TITLE
add GlobError::into_error so that errors can be easily converted

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(all(test, windows), feature(std_misc))]
 
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 use std::cmp;
 use std::fmt;
@@ -279,12 +280,18 @@ impl GlobError {
     pub fn error(&self) -> &io::Error {
         &self.error
     }
+
+    /// Consumes self, returning the _raw_ underlying `io::Error`
+    pub fn into_error(self) -> io::Error {
+        self.error
+    }
 }
 
 impl Error for GlobError {
     fn description(&self) -> &str {
         self.error.description()
     }
+
     fn cause(&self) -> Option<&Error> {
         Some(&self.error)
     }


### PR DESCRIPTION
For the `ergo_fs` crate I would like to convert `GlobError` into `PathError`. However I cannot without some performance penalty, since there is no way to get the original `io::Error` object.