### PR TITLE
Prepare for 0.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 
 name = "glob"
-version = "0.2.11"
+version = "0.3.0"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/rust-lang/glob"
 repository = "https://github.com/rust-lang/glob"
-documentation = "https://doc.rust-lang.org/glob"
+documentation = "https://docs.rs/glob/0.3.0"
 description = """
 Support for matching file paths against Unix shell style patterns.
 """

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use `glob`, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-glob = "0.2"
+glob = "0.3.0"
 ```
 
 And add this to your crate root:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://doc.rust-lang.org/glob/"
+    html_root_url = "https://docs.rs/glob/0.3.0"
 )]
 #![deny(missing_docs)]
 #![cfg_attr(all(test, windows), feature(std_misc))]


### PR DESCRIPTION
[Changes since the last release](https://github.com/rust-lang-nursery/glob/compare/04809adfc73ff910dd23a946d15d1ad34056c337...master)

Bumping from `0.2` to `0.3`. The last release was a couple of years ago and there've been a lot of changes since then so it seems safest to bump the minor version.